### PR TITLE
Fixed wrong level being returned in some cases

### DIFF
--- a/app/src/main/java/de/chuparch0pper/android/xposed/pogoiv/IVChecker.java
+++ b/app/src/main/java/de/chuparch0pper/android/xposed/pogoiv/IVChecker.java
@@ -273,7 +273,7 @@ public class IVChecker implements IXposedHookLoadPackage, IXposedHookZygoteInit 
     private float calcLevel(float cpMultiplier) {
         float level = 1;
         for (double currentCpM : Data.CpM) {
-            if (Math.abs(cpMultiplier - currentCpM) < 0.01) {
+            if (Math.abs(cpMultiplier - currentCpM) < 0.0001) {
                 return level;
             }
             level += 0.5;


### PR DESCRIPTION
Current implementation compares Pokémon CpM with values from the table using a threshold of 0.01, but this is too high since some CpM values can be very close to each other, with a difference as low as 0.0028 for the higher levels. This results in wrong level values being returned in some cases (mainly after level 11, where the delta between consecutive CpM values starts dropping below 0.01).
For instance, a level 40 Pokémon (CpM 0.7903) would be marked as level 38.5 (CpM 0.7818), since |0.7903-0.7818| < 0.01.

This PR lowers the threshold to 0.0001 in order to fix this issue.
